### PR TITLE
Install process cleanups and refactors

### DIFF
--- a/flatpaker/impl/renpy.py
+++ b/flatpaker/impl/renpy.py
@@ -14,10 +14,8 @@ if typing.TYPE_CHECKING:
     from flatpaker.description import Description
 
 
-def _create_game_sh(use_wayland: bool) -> str:
+def _create_game_sh(use_wayland: bool) -> list[str]:
     lines: typing.List[str] = [
-        '#!/usr/bin/env sh',
-        '',
         'export RENPY_PERFORMANCE_TEST=0',
         'export RENPY_NO_STEAM=1',
     ]
@@ -30,7 +28,7 @@ def _create_game_sh(use_wayland: bool) -> str:
         'exec sh *.sh',
     ])
 
-    return '\n'.join(lines)
+    return lines
 
 
 def quote(s: str) -> str:
@@ -42,11 +40,16 @@ def bd_game(description: Description) -> typing.Dict[str, typing.Any]:
     return {
         'buildsystem': 'simple',
         'name': 'game_sh',
-        'sources': [],
-        'build-commands': [
-            f"echo '{sh}' > game.sh",
-            'install -Dm755 -t /app/bin/'
+        'sources': [
+            {
+                'type': 'script',
+                'dest-filename': 'game.sh',
+                'commands': sh,
+            }
         ],
+        'build-commands': [
+            'install -Dm755 game.sh -t /app/bin'
+        ]
     }
 
 

--- a/flatpaker/impl/renpy.py
+++ b/flatpaker/impl/renpy.py
@@ -44,9 +44,8 @@ def bd_game(description: Description) -> typing.Dict[str, typing.Any]:
         'name': 'game_sh',
         'sources': [],
         'build-commands': [
-            'mkdir -p /app/bin',
-            f"echo '{sh}' > /app/bin/game.sh",
-            'chmod +x /app/bin/game.sh'
+            f"echo '{sh}' > game.sh",
+            'install -Dm755 -t /app/bin/'
         ],
     }
 
@@ -82,10 +81,7 @@ def bd_build_commands(description: Description, appid: str) -> typing.List[str]:
     for p in description.get('sources', {}).get('files', []):
         dest = os.path.join('/app/lib/game', p.get('dest', 'game'))
         # This could be a file or a directory for dest, so we can't use install
-        commands.extend([
-            f'mkdir -p {os.path.dirname(dest)}',
-            f'mv {p["path"].name} {dest}',
-        ])
+        commands.append(f'install -Dm644 {p["path"].name} {dest}')
 
     # Patch the game to not require sandbox access
     commands.append(

--- a/flatpaker/impl/renpy.py
+++ b/flatpaker/impl/renpy.py
@@ -19,6 +19,7 @@ def _create_game_sh(use_wayland: bool) -> str:
         '#!/usr/bin/env sh',
         '',
         'export RENPY_PERFORMANCE_TEST=0',
+        'export RENPY_NO_STEAM=1',
     ]
 
     if use_wayland:
@@ -239,7 +240,6 @@ def write_rules(description: Description, workdir: pathlib.Path, appid: str, des
             *finish_args,
             '--socket=pulseaudio',
             '--device=dri',
-            '--env=RENPY_NO_STEAM=1'
         ],
         'modules': modules,
         'cleanup-commands': [

--- a/flatpaker/impl/renpy.py
+++ b/flatpaker/impl/renpy.py
@@ -35,24 +35,6 @@ def quote(s: str) -> str:
     return f'"{s}"'
 
 
-def bd_game(description: Description) -> typing.Dict[str, typing.Any]:
-    sh = _create_game_sh(description.get('quirks', {}).get('x_use_wayland', False))
-    return {
-        'buildsystem': 'simple',
-        'name': 'game_sh',
-        'sources': [
-            {
-                'type': 'script',
-                'dest-filename': 'game.sh',
-                'commands': sh,
-            }
-        ],
-        'build-commands': [
-            'install -Dm755 game.sh -t /app/bin'
-        ]
-    }
-
-
 def bd_build_commands(description: Description, appid: str) -> typing.List[str]:
     commands: typing.List[str] = [
         'mkdir -p /app/lib/game',
@@ -215,9 +197,7 @@ def write_rules(description: Description, workdir: pathlib.Path, appid: str, des
         },
     ]
     modules.extend([
-        bd_game(description),
-        util.bd_desktop(desktop_file),
-        util.bd_appdata(appdata_file),
+        util.bd_metadata(desktop_file, appdata_file, _create_game_sh(description.get('quirks', {}).get('x_use_wayland', False)))
     ])
 
     if description.get('quirks', {}).get('x_use_wayland', False):

--- a/flatpaker/impl/rpgmaker.py
+++ b/flatpaker/impl/rpgmaker.py
@@ -24,11 +24,10 @@ def write_rules(description: Description, workdir: pathlib.Path, appid: str, des
     commands.extend([
         # in MV www/icon.png is usually the customized icon and icon/icon.png is
         textwrap.dedent(f'''
-            mkdir -p /app/share/icons/hicolor/256x256/apps/
             if [[ -d "www/icon" ]]; then
-                cp www/icon/icon.png /app/share/icons/hicolor/256x256/apps/{appid}.png
+                install -Dm644 www/icon/icon.png /app/share/icons/hicolor/256x256/apps/{appid}.png
             else
-                cp icon/icon.png /app/share/icons/hicolor/256x256/apps/{appid}.png
+                install -Dm644 icon/icon.png /app/share/icons/hicolor/256x256/apps/{appid}.png
             fi
         '''),
 

--- a/flatpaker/impl/rpgmaker.py
+++ b/flatpaker/impl/rpgmaker.py
@@ -53,11 +53,17 @@ def write_rules(description: Description, workdir: pathlib.Path, appid: str, des
         {
             'buildsystem': 'simple',
             'name': 'game_sh',
-            'sources': [],
+            'sources': [
+                {
+                    'type': 'script',
+                    'dest-filename': 'game.sh',
+                    'commands': [
+                        'exec /usr/lib/nwjs/nw /app/lib/game/ --enable-features=UseOzonePlatform --ozone-platform=wayland'
+                    ]
+                }
+            ],
             'build-commands': [
-                'mkdir -p /app/bin',
-                "echo  'exec /usr/lib/nwjs/nw /app/lib/game/ --enable-features=UseOzonePlatform --ozone-platform=wayland' > /app/bin/game.sh",
-                'chmod +x /app/bin/game.sh',
+                'install -Dm755 game.sh -t /app/bin'
             ],
         },
         util.bd_desktop(desktop_file),

--- a/flatpaker/impl/rpgmaker.py
+++ b/flatpaker/impl/rpgmaker.py
@@ -38,6 +38,10 @@ def write_rules(description: Description, workdir: pathlib.Path, appid: str, des
         'mv package.json www /app/lib/game/',
     ])
 
+    game_sh_contents = [
+        'exec /usr/lib/nwjs/nw /app/lib/game/ --enable-features=UseOzonePlatform --ozone-platform=wayland "$@"'
+    ]
+
     # TODO: typing requires more thought
     modules: typing.List[typing.Dict[str, typing.Any]] = [
         {
@@ -49,24 +53,7 @@ def write_rules(description: Description, workdir: pathlib.Path, appid: str, des
                 'www/save',
             ],
         },
-        {
-            'buildsystem': 'simple',
-            'name': 'game_sh',
-            'sources': [
-                {
-                    'type': 'script',
-                    'dest-filename': 'game.sh',
-                    'commands': [
-                        'exec /usr/lib/nwjs/nw /app/lib/game/ --enable-features=UseOzonePlatform --ozone-platform=wayland "$@"'
-                    ]
-                }
-            ],
-            'build-commands': [
-                'install -Dm755 game.sh -t /app/bin'
-            ],
-        },
-        util.bd_desktop(desktop_file),
-        util.bd_appdata(appdata_file),
+        util.bd_metadata(desktop_file, appdata_file, game_sh_contents),
     ]
 
     struct = {

--- a/flatpaker/impl/rpgmaker.py
+++ b/flatpaker/impl/rpgmaker.py
@@ -58,7 +58,7 @@ def write_rules(description: Description, workdir: pathlib.Path, appid: str, des
                     'type': 'script',
                     'dest-filename': 'game.sh',
                     'commands': [
-                        'exec /usr/lib/nwjs/nw /app/lib/game/ --enable-features=UseOzonePlatform --ozone-platform=wayland'
+                        'exec /usr/lib/nwjs/nw /app/lib/game/ --enable-features=UseOzonePlatform --ozone-platform=wayland "$@"'
                     ]
                 }
             ],

--- a/flatpaker/util.py
+++ b/flatpaker/util.py
@@ -164,35 +164,30 @@ def tmpdir(name: str, cleanup: bool = True) -> typing.Iterator[pathlib.Path]:
         shutil.rmtree(tdir)
 
 
-def bd_desktop(file_: pathlib.Path) -> typing.Dict[str, typing.Any]:
+def bd_metadata(desktop: pathlib.Path, appdata: pathlib.Path, game: list[str]) -> dict[str, typing.Any]:
     return {
         'buildsystem': 'simple',
-        'name': 'desktop_file',
+        'name': 'metadata',
         'sources': [
             {
-                'path': file_.as_posix(),
-                'sha256': sha256(file_),
+                'path': desktop.as_posix(),
+                'sha256': sha256(desktop),
                 'type': 'file',
+            },
+            {
+                'path': appdata.as_posix(),
+                'sha256': sha256(appdata),
+                'type': 'file',
+            },
+            {
+                'type': 'script',
+                'dest-filename': 'game.sh',
+                'commands': game,
             }
         ],
         'build-commands': [
-            f'install -D -m644 {file_.name} -t /app/share/applications',
-        ],
-    }
-
-
-def bd_appdata(file_: pathlib.Path) -> typing.Dict[str, typing.Any]:
-    return {
-        'buildsystem': 'simple',
-        'name': 'appdata_file',
-        'sources': [
-            {
-                'path': file_.as_posix(),
-                'sha256': sha256(file_),
-                'type': 'file',
-            }
-        ],
-        'build-commands': [
-            f'install -D -m644 {file_.name} -t /app/share/metainfo',
+            f'install -D -m644 {desktop.name} -t /app/share/applications',
+            f'install -D -m644 {appdata.name} -t /app/share/metainfo',
+            'install -Dm755 game.sh -t /app/bin',
         ],
     }


### PR DESCRIPTION
Use more `install`, it's handy. Also make use of some extra flatpak manifest features, and finally compact the metadata build step into a single step.

Having three steps was handy when I was doing initial bringup, but not so much now.