### PR TITLE
runtime/renpy: enable the developer tools

### DIFF
--- a/flatpaker/data/com.github.dcbaker.flatpaker.RenPy.7.py2.Sdk.yml
+++ b/flatpaker/data/com.github.dcbaker.flatpaker.RenPy.7.py2.Sdk.yml
@@ -31,7 +31,8 @@ modules:
         url: https://www.renpy.org/dl/7.8.7/pygame_sdl2-2.1.0+renpy7.8.7.tar.gz
         sha256: 8103b73e32604456db3950d4729982cd3243413a651014d06fc8196365ede37a
       - type: patch
-        path: patches/pygame-sdl2-7-remove-pathlib.patch
+        path: patches/pygame-sdl2-
+      - mv 00enabledebug.rpy renpy/common/7-remove-pathlib.patch
       - type: patch
         path: patches/pygame-sdl2-7-use-correct-cython.patch
       - type: patch
@@ -45,6 +46,8 @@ modules:
       # and causes a crash. It's also not useful since there is no steam in the
       # sandbox
       - rm renpy/common/00steam.rpy* || true
+
+      - mv 00enabledebug.rpy renpy/common/
 
       # TODO: calculate where site packages is instead of hardocding
       - cp -rv renpy ${FLATPAK_DEST}/lib/python2.7/site-packages || exit 1
@@ -76,6 +79,8 @@ modules:
       - type: file
         path: files/renpy.py
         dest-filename: renpy-bin
+      - type: file
+        path: files/00enabledebug.rpy
     cleanup:
       - /app
 

--- a/flatpaker/data/com.github.dcbaker.flatpaker.RenPy.7.py3.Sdk.yml
+++ b/flatpaker/data/com.github.dcbaker.flatpaker.RenPy.7.py3.Sdk.yml
@@ -35,6 +35,8 @@ modules:
       # sandbox
       - rm renpy/common/00steam.rpy* || true
 
+      - mv 00enabledebug.rpy renpy/common/
+
       # TODO: calculate where site packages is instead of hardocding
       - cp -rv renpy ${FLATPAK_DEST}/lib/python3.12/site-packages || exit 1
       - python -m compileall ${FLATPAK_DEST}/lib/python3.12/site-packages/renpy || exit 1
@@ -64,6 +66,8 @@ modules:
       - type: file
         path: files/renpy.py
         dest-filename: renpy-bin
+      - type: file
+        path: files/00enabledebug.rpy
     cleanup:
       - /app
 

--- a/flatpaker/data/com.github.dcbaker.flatpaker.RenPy.8.Sdk.yml
+++ b/flatpaker/data/com.github.dcbaker.flatpaker.RenPy.8.Sdk.yml
@@ -31,6 +31,8 @@ modules:
       # sandbox
       - rm renpy/common/00steam.rpy* || true
 
+      - mv 00enabledebug.rpy renpy/common/
+
       # TODO: calculate where site packages is instead of hardocding
       - cp -rv renpy ${FLATPAK_DEST}/lib/python3.12/site-packages || exit 1
       - python -m compileall ${FLATPAK_DEST}/lib/python3.12/site-packages/renpy || exit 1
@@ -58,6 +60,8 @@ modules:
       - type: file
         path: files/renpy.py
         dest-filename: renpy-bin
+      - type: file
+        path: files/00enabledebug.rpy
     cleanup:
       - /app
 

--- a/flatpaker/data/files/00enabledebug.rpy
+++ b/flatpaker/data/files/00enabledebug.rpy
@@ -1,0 +1,3 @@
+init +1:
+    python hide:
+        config.developer = True


### PR DESCRIPTION
I find these useful for debugging, others might find them useful for cheating. Either way, they're useful.