### PR TITLE
runtime/renpy: Add unrpyc to the SDK

### DIFF
--- a/flatpaker/data/modules/renpy-shared.yml
+++ b/flatpaker/data/modules/renpy-shared.yml
@@ -66,3 +66,14 @@ modules:
       - type: "archive"
         url: https://www.rarlab.com/rar/unrarsrc-7.1.6.tar.gz
         sha256: ca5e1da37dd6fa1b78bb5ed675486413f79e4a917709744aa04b6f93dfd914f0
+
+  - name: un.rpyc
+    buildsystem: "simple"
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} . --no-build-isolation
+    cleanup-platform:
+      - '*'
+    sources:
+      - type: "git"
+        url: "https://github.com/CensoredUsername/unrpyc.git"
+        tag: v2.0.2


### PR DESCRIPTION
Like the unrpa and rpatool components, these use the freedesktop platform's python3 install regardless of whether renpy is using python 2 and or python3.