### PR TITLE
quirks: Add an experimental quirk for Ren'Py games that need an icon from a .rpa file

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,10 @@ For example:
     of extracting icons from the exe or icns files. This is generally
     unnecessary, but some games have customized window_icons but not exe icons.
 
+  - `x_renpy_archived_window_gui_icon: string`. Extract a `gui/window_icon.png` file
+    from the named archive instead of extracting from the exe or icns files.
+    This is generally unnecessary, but see above.
+
 
 ##### RPGMaker
 

--- a/flatpaker.schema.json
+++ b/flatpaker.schema.json
@@ -233,6 +233,10 @@
                 "x_rpgmaker_repack_www": {
                     "description": "Automatically pack an exploded layout into a www/ layout",
                     "type": "boolean"
+                },
+                "x_renpy_archived_window_gui_icon": {
+                    "description": "Extract a windows_gui.png icon from the named .rpa",
+                    "type": "string"
                 }
             }
         }

--- a/flatpaker/description.py
+++ b/flatpaker/description.py
@@ -72,6 +72,11 @@ class Quirks:
     force_window_gui_icon: bool = False
     x_configure_prologue: str | None = None
     x_rpgmaker_repack_www: bool = False
+    x_renpy_archived_window_gui_icon: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.force_window_gui_icon and self.x_renpy_archived_window_gui_icon:
+            raise RuntimeError('Cannot require both an unpacked windows_gui.png and a packed windows_gui.png!')
 
 
 @dataclasses.dataclass

--- a/flatpaker/impl/renpy.py
+++ b/flatpaker/impl/renpy.py
@@ -53,6 +53,11 @@ def bd_build_commands(description: Description) -> typing.List[str]:
     if description.quirks.force_window_gui_icon:
         commands.append(
             'install -D -m644 $FLATPAK_DEST/lib/game/game/gui/window_icon.png $FLATPAK_DEST/share/icons/hicolor/256x256/apps/$FLATPAK_ID.png')
+    elif (arch := description.quirks.x_renpy_archived_window_gui_icon) is not None:
+        commands.extend([
+            f'rpatool $FLATPAK_DEST/lib/game/game/{arch} -x $FLATPAK_ID.png=gui/window_icon.png || exit 1',
+            'install -Dm644 ${FLATPAK_ID}.png -t ${FLATPAK_DEST}/share/icons/hicolor/256x256/apps || exit 1',
+        ])
     else:
         commands.append(
             # Extract the icon file from either a Windows exe or from MacOS resources.


### PR DESCRIPTION


I've run into a few games now that don't have customized .exe or icns icons, and don't have a game/gui/windows_icon.png, but have a `gui/windows_icon.png` inside of an rpa.

This allows for a simpler experience with this issue