### PR TITLE
python: Drop support for Python 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@
   authors = [{ name = "Dylan Baker", email = "dylan@pnwbakers.com" }]
   dynamic = ["version", "description"]
   readme = "README.md"
-  requires-python = ">=3.9"
+  requires-python = ">=3.10"
   keywords = ["flatpak", "renpy", "rpgmaker"]
   license = { text = "MIT" }
   classifiers = [
@@ -15,7 +15,6 @@
     "Environment :: Console",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
Which is EOL