### PR TITLE
devcontainer: Add basic devcontainer setup

### DIFF
--- a/.devcontainer/.gitignore
+++ b/.devcontainer/.gitignore
@@ -1,0 +1,1 @@
+devcontainer-lock.json

--- a/.devcontainer/debian-install.sh
+++ b/.devcontainer/debian-install.sh
@@ -1,0 +1,30 @@
+set -exo pipefail
+
+apt update -y
+
+apt install -y \
+    python3 \
+    appstream \
+    flatpak-builder \
+    python3-pip \
+    rustup \
+    libglib2.0-dev \
+    libostree-dev \
+    ;
+
+apt clean -y
+
+pip install --break-system-packages \
+    flit \
+    mypy \
+    packaging \
+    requirements-parser \
+    ruff \
+    tomlkit \
+    ;
+
+rustup default stable
+
+cargo install --git https://github.com/flatpak/flat-manager flat-manager-client
+
+flatpak remote-add --if-not-exists --user flathub https://flathub.org/repo/flathub.flatpakrepo

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,46 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/debian
+{
+  "name": "flatpaker",
+
+  // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+  "image": "mcr.microsoft.com/devcontainers/base:trixie",
+
+  // These are required to let bubblewrap run inside the container
+  "capAdd": ["SYS_ADMIN"],
+  "securityOpt": ["seccomp=unconfined", "unmask=ALL"],
+  "runArgs": ["--device=/dev/fuse"],
+
+  // Features to add to the dev container. More info: https://containers.dev/features.
+  // "features": {
+  //  "ghcr.io/devcontainer-config/features/dot-config:4": {}
+  // },
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
+
+  // Configure tool-specific properties.
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "EditorConfig.EditorConfig",
+        "charliermarsh.ruff",
+        "ms-python.mypy-type-checker",
+        "ms-python.pylint",
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "njpwerner.autodocstring",
+        "tamasfe.even-better-toml",
+      ]
+    }
+  },
+
+  "remoteEnv": {
+    "PATH": "${containerEnv:PATH}:~/.cargo/bin",
+  },
+
+  "onCreateCommand": "sudo sh .devcontainer/debian-install.sh",
+
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  "remoteUser": "root",
+}

--- a/.editorconfig
+++ b/.editorconfig
@@ -16,3 +16,6 @@ indent_size = 2
 
 [*.yml]
 indent_size = 2
+
+[*.json]
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Vscode
+.vscode/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -124,6 +127,9 @@ venv.bak/
 .mypy_cache/
 .dmypy.json
 dmypy.json
+
+# Ruff
+.ruff_cache/
 
 # Pyre type checker
 .pyre/


### PR DESCRIPTION
This requires a bunch of permissions in order to get bubblewrap working inside the container.

It also adds flat-manager-client, which I plan to integrate into flatpaker in the near future as an export target.