### PR TITLE
Update RPGMaker runtime

### DIFF
--- a/flatpaker/data/com.github.dcbaker.flatpaker.RPGM.Platform.yml
+++ b/flatpaker/data/com.github.dcbaker.flatpaker.RPGM.Platform.yml
@@ -10,8 +10,8 @@ modules:
    buildsystem: "simple"
    sources:
     - type: "archive"
-      url: "https://dl.nwjs.io/v0.100.1/nwjs-v0.100.1-linux-x64.tar.gz"
-      sha256: "12a2c448be3355d07316f84f8177dc23049534d05520ccb549d0aee9e354f7a4"
+      url: "https://dl.nwjs.io/v0.114.1/nwjs-v0.114.1-linux-x64.tar.gz"
+      sha256: "35e53de9b37edf8a0cd77068d74728bcd470ae6569f88a4a15b97d27647635db"
       only_arches:
        - x86_64
    build-commands:

--- a/flatpaker/data/com.github.dcbaker.flatpaker.RPGM.Platform.yml
+++ b/flatpaker/data/com.github.dcbaker.flatpaker.RPGM.Platform.yml
@@ -14,6 +14,11 @@ modules:
       sha256: "35e53de9b37edf8a0cd77068d74728bcd470ae6569f88a4a15b97d27647635db"
       only_arches:
        - x86_64
+    - type: "archive"
+      url: "https://dl.nwjs.io/v0.114.1/nwjs-v0.114.1-linux-arm64.tar.gz"
+      sha256: "40befc36553e189151a3d89481da2aa02b1d250df447f57020e142e1953090ff"
+      only_arches:
+       - aarch64
    build-commands:
     - "mkdir /usr/lib/nwjs"
     - "mv * /usr/lib/nwjs/"

--- a/flatpaker/impl/rpgmaker.py
+++ b/flatpaker/impl/rpgmaker.py
@@ -47,7 +47,7 @@ def write_rules(description: Description, workdir: pathlib.Path, appid: str, des
     ])
 
     game_sh_contents = [
-        'exec /usr/lib/nwjs/nw /app/lib/game/ --enable-features=UseOzonePlatform --ozone-platform=wayland "$@"'
+        'exec /usr/lib/nwjs/nw /app/lib/game/ --enable-features=UseOzonePlatform --ozone-platform=auto "$@"'
     ]
 
     # TODO: typing requires more thought
@@ -77,6 +77,7 @@ def write_rules(description: Description, workdir: pathlib.Path, appid: str, des
         'finish-args': [
             '--socket=pulseaudio',
             '--socket=wayland',
+            '--socket=fallback-x11',
             '--device=dri',
         ],
         'modules': modules,


### PR DESCRIPTION
This updates nwjs to 114.1. This gives an updated chromium base that allows `--ozone-platform=auto`, which allows us to enable fallback-x11 support. Additionally, it allows experimental Aarch64 support.